### PR TITLE
שדה מקור ליד

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/fb_leads_bot.py
+++ b/fb_leads_bot.py
@@ -201,9 +201,13 @@ def move_to_mailbox(mail_conn, uid: str, mailbox: str) -> bool:
     if not mailbox:
         return False
     try:
-        mb = mailbox
-        if (" " in mb) and not (mb.startswith('"') and mb.endswith('"')):
-            mb = f"\"{mb}\""
+        # צריך לצטט שמות תיבות (במיוחד עם רווחים). נשתמש במנגנון הציטוט של imaplib אם קיים.
+        try:
+            mb = mail_conn._quote(mailbox)
+        except Exception:
+            mb = mailbox
+            if (" " in mb) and not (mb.startswith('"') and mb.endswith('"')):
+                mb = f"\"{mb}\""
         # ננסה ליצור את התיבה אם לא קיימת (חלק מהשרתים יחזירו NO אם קיימת)
         try:
             mail_conn.create(mb)


### PR DESCRIPTION
טופל ב־Issue #1
מניעת “תקיעה” על מייל בעייתי: אם ה־AI נכשל / מחזיר None או שיש Exception בעיבוד, המייל לא נשאר UNSEEN. הוא מסומן \Seen וגם \Flagged כדי שתוכל למצוא אותו בקלות.
מעבר לעבודה עם IMAP UIDs: כל הזרימה עודכנה ל־UID SEARCH / UID FETCH / UID STORE (מזהים יציבים שלא משתנים כשנמחקים מיילים אחרים).
אופציונלי: אם מגדירים ERROR_MAILBOX (למשל Error), מיילים שנכשלו בעיבוד יועברו לשם במקום רק סימון Seen.
איפה זה נמצא


Implement IMAP UIDs and robust error handling to prevent infinite loops on problematic emails and ensure stable email identification.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-6f96c6af-b56f-4f5a-a17a-b7796c1eefca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6f96c6af-b56f-4f5a-a17a-b7796c1eefca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

