### PR TITLE
פלט בוט חסר

### DIFF
--- a/fb_leads_bot.py
+++ b/fb_leads_bot.py
@@ -74,7 +74,9 @@ client = OpenAI(api_key=OPENAI_API_KEY)
 
 def log(msg: str):
     """לוג עם timestamp"""
-    print(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] {msg}")
+    # חשוב ל-Render/containers: stdout הוא לא TTY ולכן Python עלול לא לעשות flush מיידי.
+    # flush=True מבטיח שתראה לוגים בזמן אמת.
+    print(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] {msg}", flush=True)
 
 
 def make_fingerprint(subject: str, snippet: str) -> str:
@@ -423,10 +425,13 @@ def main_loop():
 
     while True:
         try:
+            log("🔎 בודק מיילים חדשים מפייסבוק...")
             mail_conn, emails = fetch_facebook_emails()
 
             if emails:
                 log(f"📬 נמצאו {len(emails)} מיילים חדשים")
+            else:
+                log("📭 אין מיילים חדשים (UNSEEN) כרגע")
 
             alerts_sent = 0
             for email_data in emails:


### PR DESCRIPTION
)
הבוט לא בודק פייסבוק בכלל (לא פוסטים ולא תגובות) דרך API/סקראפינג. הוא בודק רק מיילים שמגיעים לתיבה, ואז מנתח את תוכן המייל.
אז “תגובה שהיה צריך להתריע עליה” תזוהה רק אם פייסבוק שלח עליה מייל שנכנס לתיבה (והוא UNSEEN) והטקסט שלו עבר את סינון מילות המפתח.

למה “היו המון פוסטים” ועדיין אין כלום
זה לא נספר לפי מה שקורה בפייסבוק, אלא לפי מה שיש במייל. בנוסף יש בקוד תנאים שמאוד מצמצמים:

הוא מחפש רק מיילים שהם UNSEEN
רק ב־inbox
ורק מ־facebookmail.com
אם המיילים כבר נקראו/הגיעו ממדומיין אחר/נכנסו לספאם—הוא לא יראה אותם.
תיקון ללוגים ב-Render (כדי שתראה שהוא עובד)
דחפתי שינוי שמתקן את הבעיה הכי נפוצה ב-Render: buffering של stdout.
עכשיו כל לוג עושה flush=True ויש גם “heartbeat” בכל סבב בדיקה, כך שתראה בלוגים משהו כמו:

🔎 בודק מיילים...
📭 אין מיילים חדשים... / 📬 נמצאו ...
אם אחרי ה-Deploy הבא עדיין אין לוגים בכלל—זה כבר כמעט בטוח אומר שהפרוסס לא באמת רץ/לא ב־Runtime logs.






Improve logging visibility to ensure bot activity is shown in Render logs.

This change adds `flush=True` to log calls and a "heartbeat" message in each check cycle to overcome Python's stdout buffering issues in Render, allowing users to see bot activity.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-8b2f00a7-1de0-4065-9716-5ddbaff2a496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8b2f00a7-1de0-4065-9716-5ddbaff2a496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

