### PR TITLE
אימות imap xoauth2

### DIFF
--- a/env.example.
+++ b/env.example.
@@ -1,7 +1,23 @@
-# Gmail - חובה להשתמש בסיסמת אפליקציה (App Password)
+# Gmail - מומלץ להשתמש בסיסמת אפליקציה (App Password)
 # הוראות: Google Account → Security → 2-Step Verification → App passwords
 EMAIL_USER=your_email@gmail.com
 EMAIL_PASS=your_app_password_here
+
+# IMAP endpoint (מומלץ להגדיר מפורשות כדי לא ליפול על ברירת מחדל לא נכונה)
+IMAP_PROVIDER=gmail
+IMAP_SERVER=imap.gmail.com
+IMAP_PORT=993
+IMAP_AUTH_METHOD=basic
+
+# Outlook/Office365 (אם אתה משתמש ב-Microsoft OAuth2 ל-IMAP)
+# IMAP_PROVIDER=outlook
+# IMAP_SERVER=outlook.office365.com
+# IMAP_PORT=993
+# IMAP_AUTH_METHOD=xoauth2
+# MS_TENANT=consumers
+# MS_CLIENT_ID=...
+# MS_REFRESH_TOKEN=...
+# (אופציונלי) MS_CLIENT_SECRET=...
 
 # OpenAI API Key
 # https://platform.openai.com/api-keys


### PR DESCRIPTION
Automatically infers IMAP server and authentication method based on the email domain and updates `env.example` to guide Gmail users.

The bot was defaulting to Outlook IMAP settings and attempting Microsoft XOAUTH2 even when the user had switched to a Gmail account, leading to `BasicAuthBlocked` errors. This PR fixes the inference logic and provides clearer configuration guidance.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-a4270040-0bcf-45a1-8d94-1bdd0af4d03c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a4270040-0bcf-45a1-8d94-1bdd0af4d03c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

